### PR TITLE
correctly escape ' character

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -32,8 +32,8 @@
         <item>Gearbox Temperature</item>
         <item>Speed</item>
         <item>RPM</item>
-        <item>Lateral G's</item>
-        <item>Longitudinal G's</item>
+        <item>Lateral G\'s</item>
+        <item>Longitudinal G\'s</item>
         <item>Yaw rate</item>
         <item>Wheel Angle</item>
         <item>Accelerator Position</item>
@@ -85,8 +85,8 @@
         <item>RPM</item>
         <item>Speed</item>
         <item>Current Gear</item>
-        <item>Lateral G's</item>
-        <item>Longitudinal G's</item>
+        <item>Lateral G\'s</item>
+        <item>Longitudinal G\'s</item>
         <item>Yaw rate</item>
         <item>Wheel Angle</item>
         <item>Accelerator Position</item>


### PR DESCRIPTION
Can cause errors:

![image](https://user-images.githubusercontent.com/10217641/35935041-87615852-0c3f-11e8-9d7f-ed0a38d3a5cb.png)

https://developer.android.com/guide/topics/resources/string-resource.html#FormattingAndStyling
If you have an apostrophe (') in your string, you must either escape it with a backslash (\') ...

